### PR TITLE
fix: fix typo on comment

### DIFF
--- a/gcp/resource-definitions/gcs-concrete.yaml
+++ b/gcp/resource-definitions/gcs-concrete.yaml
@@ -1,4 +1,4 @@
-# This Resource Definition of type `gcs` implements the "conrete" resource in the Delegator pattern
+# This Resource Definition of type `gcs` implements the "concrete" resource in the Delegator pattern
 # It uses the Terraform Driver to provision a gcs bucket
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition

--- a/gcp/resource-definitions/spanner-instance-concrete.yaml
+++ b/gcp/resource-definitions/spanner-instance-concrete.yaml
@@ -1,4 +1,4 @@
-# This Resource Definition of type `spanner-instance` implements the "conrete" resource in the Delegator pattern
+# This Resource Definition of type `spanner-instance` implements the "concrete" resource in the Delegator pattern
 # It uses the Terraform Driver to provision a spanner instance
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition


### PR DESCRIPTION
Fix a small typo in 2 Terraform resource definitions.