### PR TITLE
fix(aws config): driver account should be refixed by org

### DIFF
--- a/aws/common/resource-definitions/app-config.yaml
+++ b/aws/common/resource-definitions/app-config.yaml
@@ -10,7 +10,7 @@ entity:
   driver_type: humanitec/template
   # The identity used in this Cloud Account needs permission to manage
   # the kinds of cloud resources used in the example
-  driver_account: YOURVALUE
+  driver_account: YOURACCOUNT
   driver_inputs:
     values:
       templates:

--- a/aws/common/resource-definitions/tf-runner-config.yaml
+++ b/aws/common/resource-definitions/tf-runner-config.yaml
@@ -17,7 +17,7 @@ entity:
             # Terraform Runner Jobs on the cluster defined below
             # It is NOT used to execute the actual Terraform. That is done using the identity
             # of the "driver_account" defined in the individual Resource Definitions
-            account: YOURORG/YOURVALUE
+            account: YOURORG/YOURACCOUNT
             cluster:
               name: YOURVALUE
               region: YOURVALUE

--- a/gcp/common/resource-definitions/app-config.yaml
+++ b/gcp/common/resource-definitions/app-config.yaml
@@ -10,7 +10,7 @@ entity:
   driver_type: humanitec/template
   # The identity used in this Cloud Account needs permission to manage
   # the kinds of cloud resources used in the example
-  driver_account: YOURORG/YOURACCOUNT
+  driver_account: YOURACCOUNT
   driver_inputs:
     values:
       templates:

--- a/gcp/common/resource-definitions/app-config.yaml
+++ b/gcp/common/resource-definitions/app-config.yaml
@@ -10,7 +10,7 @@ entity:
   driver_type: humanitec/template
   # The identity used in this Cloud Account needs permission to manage
   # the kinds of cloud resources used in the example
-  driver_account: YOURVALUE
+  driver_account: YOURORG/YOURACCOUNT
   driver_inputs:
     values:
       templates:

--- a/gcp/common/resource-definitions/gke-config.yaml
+++ b/gcp/common/resource-definitions/gke-config.yaml
@@ -10,7 +10,7 @@ entity:
   driver_type: humanitec/template
   # The identity configured in this Cloud Account needs permission
   # to deploy Workloads to your GKE cluster
-  driver_account: YOURORG/YOURACCOUNT
+  driver_account: YOURACCOUNT
   driver_inputs:
     values:
       templates:


### PR DESCRIPTION
As we do in [gke-config.yaml](https://github.com/humanitec-tutorials/k8s-workload-identity/blob/1ab55a7c1a988aba5fce42688cde08a0ee0267dc/gcp/common/resource-definitions/gke-config.yaml#L13), we should specify that the `driver_account` is supposed to be prefixed by the org id.